### PR TITLE
Fix event description nil

### DIFF
--- a/lib/jekyll-ical-tag/event.rb
+++ b/lib/jekyll-ical-tag/event.rb
@@ -17,7 +17,7 @@ module Jekyll
 
       def simple_html_description
         @simple_html_description ||= begin
-          description.clone.tap do |d|
+          description&.clone.tap do |d|
             description_urls.each do |url|
               d.gsub! url, %(<a href='#{url}'>#{url}</a>)
             end


### PR DESCRIPTION
When you load an ICS file where an event does not have a description the plugin crashes because description is not set. For example, try a free-busy calendar from Google.

```
  Liquid Exception: can't clone NilClass in meeting.html
bundler: failed to load command: jekyll (/usr/local/bin/jekyll)
TypeError: can't clone NilClass
  /Users/omar/.bundle/ruby/2.3.0/jekyll-ical-tag-c4037ee6306e/lib/jekyll-ical-tag/event.rb:20:in `clone'
  /Users/omar/.bundle/ruby/2.3.0/jekyll-ical-tag-c4037ee6306e/lib/jekyll-ical-tag/event.rb:20:in `simple_html_description'
  /Users/omar/.bundle/ruby/2.3.0/jekyll-ical-tag-c4037ee6306e/lib/jekyll-ical-tag.rb:49:in `block (2 levels) in render'
  /Users/omar/.bundle/ruby/2.3.0/jekyll-ical-tag-c4037ee6306e/lib/jekyll-ical-tag.rb:43:in `each'
  /Users/omar/.bundle/ruby/2.3.0/jekyll-ical-tag-c4037ee6306e/lib/jekyll-ical-tag.rb:43:in `each_with_index'
  /Users/omar/.bundle/ruby/2.3.0/jekyll-ical-tag-c4037ee6306e/lib/jekyll-ical-tag.rb:43:in `block in render'
  /Library/Ruby/Gems/2.3.0/gems/liquid-4.0.1/lib/liquid/context.rb:123:in `stack'
  /Users/omar/.bundle/ruby/2.3.0/jekyll-ical-tag-c4037ee6306e/lib/jekyll-ical-tag.rb:42:in `render'
  /Library/Ruby/Gems/2.3.0/gems/liquid-4.0.1/lib/liquid/block_body.rb:102:in `render_node_to_output'
  /Library/Ruby/Gems/2.3.0/gems/liquid-4.0.1/lib/liquid/block_body.rb:82:in `render'
  /Library/Ruby/Gems/2.3.0/gems/liquid-4.0.1/lib/liquid/template.rb:208:in `block in render'
  /Library/Ruby/Gems/2.3.0/gems/liquid-4.0.1/lib/liquid/template.rb:242:in `with_profiling'
  /Library/Ruby/Gems/2.3.0/gems/liquid-4.0.1/lib/liquid/template.rb:207:in `render'
  /Library/Ruby/Gems/2.3.0/gems/liquid-4.0.1/lib/liquid/template.rb:220:in `render!'
  /Library/Ruby/Gems/2.3.0/gems/jekyll-3.7.4/lib/jekyll/liquid_renderer/file.rb:30:in `block (2 levels) in render!'
  /Library/Ruby/Gems/2.3.0/gems/jekyll-3.7.4/lib/jekyll/liquid_renderer/file.rb:42:in `measure_bytes'
  /Library/Ruby/Gems/2.3.0/gems/jekyll-3.7.4/lib/jekyll/liquid_renderer/file.rb:29:in `block in render!'
```