### PR TITLE
Fix "incompatible character encodings" error.

### DIFF
--- a/lib/jekyll-ical-tag/event.rb
+++ b/lib/jekyll-ical-tag/event.rb
@@ -19,7 +19,7 @@ module Jekyll
         @simple_html_description ||= begin
           description&.clone.tap do |d|
             description_urls.each do |url|
-              d.gsub! url, %(<a href='#{url}'>#{url}</a>)
+              d.force_encoding("UTF-8").gsub! url, %(<a href='#{url}'>#{url}</a>)
             end
           end
         end


### PR DESCRIPTION
Certain input from iCalendar-formatted files resulted in an uncaught
"incompatible character encodings" exception when requesting the
`simple_html_description` of the event. Jekyll build failures result.

For example, if a user enters emoji into a Google Calendar description
field, the `.ics` file produced by Google Calendar will be in UTF-8. If
the system running `jekyll build` does not set `UTF-8` to be the default
character encoding, the "incompatible character encodings" error will be
triggered, failing the build.

This commit (lazily?) addresses the issue by forcing the cloned
`description` variable to the same encoding as the `url` string is
encoded in, which is set to `"UTF-8"` by `description_urls`, earlier.