### PR TITLE
The version of this Gem *actually* published on RubyGems.org.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,4 +103,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/lib/jekyll-ical-tag/version.rb
+++ b/lib/jekyll-ical-tag/version.rb
@@ -1,8 +1,7 @@
-
 # frozen_string_literal: true
 
 module Jekyll
   class IcalTag < Liquid::Block
-    VERSION = "1.0.5"
+    VERSION = "1.0.6"
   end
 end


### PR DESCRIPTION
Not sure what happened with the latest version release, but this code appears to be on RubyGems and not in your GitHub repository. Figured I'd send you a PR with the diff so that the two sources show parity.