### PR TITLE
Implement `limit` for `ical` looping block tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ plugins:
 
 - `before_date` - limits returned events to dates before a specific date. This gets parsed with Ruby's Time.parse (e.g. 01-01-2018)
 - `after_date` - limits returned events to dates before a specific date. This gets parsed with Ruby's Time.parse (e.g. 01-01-2018).
+- `limit` - limits the number of returned events to the first N events matching the specified criteria. For example, `{% ical url: https://example.com/events.ics only_future:true limit:5 %}` returns the first five future events.
 
 ## Event Attributes:
 

--- a/lib/jekyll-ical-tag.rb
+++ b/lib/jekyll-ical-tag.rb
@@ -18,6 +18,7 @@ module Jekyll
       @markup = markup
 
       scan_attributes!
+      set_limit!
       set_reverse!
       set_url!
       set_only!
@@ -37,6 +38,9 @@ module Jekyll
       parser = CalendarLimiter.new(parser, after_date: @after_date)
 
       events = parser.events
+      if @limit
+        events = events.first(@limit)
+      end
       length = events.length
 
       context.stack do
@@ -90,6 +94,14 @@ module Jekyll
       @attributes = {}
       @markup.scan(Liquid::TagAttributes) do |key, value|
         @attributes[key] = value
+      end
+    end
+
+    def set_limit!
+      if @attributes["limit"]
+        @limit = @attributes["limit"].to_i
+      else
+        @limit = nil
       end
     end
 


### PR DESCRIPTION
This brings the `ical` tag into greater parity with Jekyll's `for` Liquid block by providing `limit` attribute that works as one would expect. This can be combined with other attributes such as `only_future` in order to limit the number of events looped over in the block to only those events that are the first N events in the future.