### PR TITLE
Allow passing local variables to the `ical` tag's `url` parameter.

### DIFF
--- a/lib/jekyll-ical-tag.rb
+++ b/lib/jekyll-ical-tag.rb
@@ -31,6 +31,11 @@ module Jekyll
 
       result = []
 
+      # Dereference the URL if we were passed a variable name.
+      if context.scopes.first[@url]
+        @url = context.scopes.first[@url]
+      end
+
       parser = CalendarParser.new(@url)
       parser = CalendarLimiter.new(parser, only: @only)
       parser = CalendarLimiter.new(parser, reverse: @reverse)


### PR DESCRIPTION
This increases the utility of the plugin by allowing the `url` parameter
to accept the name of a variable in the (first) local scope to its
rendering context. In other words, this allows uses such as:

```
{% assign url = page.calendar_address %}
{% ical url: url %}
...
{% endical %}
```

This is particularly useful for layouts, includes, and other non-leaf
areas of Jekyll's templating system in which it does not make sense to
hardcode a given iCalendar URL.