### PR TITLE
Local scope, page variables, and refactor; oh my!

### DIFF
--- a/_plugins/ical_tag.rb
+++ b/_plugins/ical_tag.rb
@@ -46,6 +46,8 @@ class CalendarLimiter
       parser.events.select do |event|
         event.dtstart.to_time < options[:before_date]
       end
+    when options[:limit]
+      parser.events.first(options[:limit].to_i)
     else
       parser.events
     end
@@ -150,8 +152,7 @@ module Jekyll
       only_past = @attributes["only_past"] == "true"
 
       raise "Set only_future OR only_past, not both" if only_future && only_past
-      @only =
-        case
+      @only = case
         when only_future
           :future
         when only_past
@@ -162,8 +163,7 @@ module Jekyll
     end
 
     def set_before_date!
-      @before_date =
-        begin
+      @before_date = begin
           if @attributes["before_date"]
             Time.parse(@attributes["before_date"])
           end
@@ -173,8 +173,7 @@ module Jekyll
     end
 
     def set_after_date!
-      @after_date =
-        begin
+      @after_date = begin
           if @attributes["after_date"]
             Time.parse(@attributes["after_date"])
           end

--- a/lib/jekyll-ical-tag.rb
+++ b/lib/jekyll-ical-tag.rb
@@ -31,6 +31,11 @@ module Jekyll
 
       result = []
 
+      # Dereference the URL if we were passed a variable name.
+      if context.scopes.first[@url]
+        @url = context.scopes.first[@url]
+      end
+
       parser = CalendarParser.new(@url)
       parser = CalendarLimiter.new(parser, only: @only)
       parser = CalendarLimiter.new(parser, reverse: @reverse)

--- a/lib/jekyll-ical-tag.rb
+++ b/lib/jekyll-ical-tag.rb
@@ -40,11 +40,9 @@ module Jekyll
       parser = CalendarLimiter.new(parser, reverse: @reverse)
       parser = CalendarLimiter.new(parser, before_date: @before_date)
       parser = CalendarLimiter.new(parser, after_date: @after_date)
+      parser = CalendarLimiter.new(parser, limit: @limit)
 
       events = parser.events
-      if @limit
-        events = events.first(@limit)
-      end
       length = events.length
 
       context.stack do
@@ -102,11 +100,8 @@ module Jekyll
     end
 
     def set_limit!
-      if @attributes["limit"]
-        @limit = @attributes["limit"].to_i
-      else
-        @limit = nil
-      end
+      @limit = nil
+      @limit = @attributes["limit"].to_i if @attributes["limit"]
     end
 
     def set_reverse!

--- a/lib/jekyll-ical-tag/calendar_limiter.rb
+++ b/lib/jekyll-ical-tag/calendar_limiter.rb
@@ -31,6 +31,8 @@ module Jekyll
           parser.events.select do |event|
             event.dtstart.to_time < options[:before_date]
           end
+        when options[:limit]
+          parser.events.first(options[:limit])
         else
           parser.events
         end

--- a/lib/jekyll-ical-tag/version.rb
+++ b/lib/jekyll-ical-tag/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   class IcalTag < Liquid::Block
-    VERSION = "1.0.8"
+    VERSION = "1.0.9"
   end
 end


### PR DESCRIPTION
Support many ways to set `url` for the `ical` tag

```markdown
---
cal_url: "https://space.floern.com/launch.ics"
---

{% ical url: page.cal_url %}
  {{ event.summary }}
{% endical %}

{% assign url = "https://space.floern.com/launch.ics" %}
{% ical url: url %}
  {{ event.summary }}
{% endical %}

{% ical url: https://space.floern.com/launch.ics %}
  {{ event.summary }}
{% endical %}
```

Close @11; Thanks @meitar 

Version 1.0.9 will be published soon