### PR TITLE
Search nested scopes for URL value. This allows use in Jekyll loops.

### DIFF
--- a/lib/jekyll-ical-tag.rb
+++ b/lib/jekyll-ical-tag.rb
@@ -104,10 +104,16 @@ module Jekyll
 
     def set_url_from_assigned_value!(context)
       return if has_valid_url?
-      return unless context.scopes.first[@url]
 
       # Dereference the URL if we were passed a variable name.
-      @url = context.scopes.first[@url]
+      url = nil
+      for s in context.scopes
+        if s[@url]
+          url = s[@url]
+          break # First match found is the one we want.
+        end
+      end
+      @url = url
     end
 
     def as_utf8(str)


### PR DESCRIPTION
Prior to this commit, a Liquid exception like the following would be
produced:

```
Liquid Exception: undefined method `split' for nil:NilClass in [...]
```

when a template included code such as the following:

```
{% for cal in site.calendars %}
{% assign url = cal.icalendar_address %}
{% ical url: url %}{% endical %}
{% endfor %}
```

This was caused by the limitation of searching only the first scope in
the `context.scopes` array. This commit addresses the issue by iterating
over all local scopes.