### PR TITLE
Dereference variables without using `dig`

### DIFF
--- a/lib/jekyll-ical-tag.rb
+++ b/lib/jekyll-ical-tag.rb
@@ -31,8 +31,7 @@ module Jekyll
       result = []
 
       context.stack do
-        url = get_url_from_assigned_value(context) ||
-              get_url_from_page_attributes(context) ||
+        url = get_dereferenced_url(context) ||
               @url
 
         raise "No URL provided or in innapropriate form '#{url}'" unless is_valid_url?(url)
@@ -117,29 +116,10 @@ module Jekyll
       !!(url =~ URI::regexp)
     end
 
-    def get_url_from_page_attributes(context)
-      return if is_valid_url?(@url)
+    def get_dereferenced_url(context)
+      return unless context.key?(@url)
 
-      # Dereference url from something like "page.calendar_url" to the page's calendar_url
-      attributes = @url.split(".")
-      attributes[0] = attributes[0].to_sym if attributes[0].present?
-
-      result = context.registers
-      attributes.each { |attribute| result = result&.fetch(attribute) }
-
-      if is_valid_url?(result)
-        result
-      else
-        nil
-      end
-    end
-
-    def get_url_from_assigned_value(context)
-      return if is_valid_url?(@url)
-      return unless scope = context.scopes.find { |scope| scope[@url] }
-
-      # Dereference the URL if we were passed a variable name.
-      scope[@url]
+      context[@url]
     end
 
     def scan_attributes!

--- a/lib/jekyll-ical-tag.rb
+++ b/lib/jekyll-ical-tag.rb
@@ -79,6 +79,8 @@ module Jekyll
                 value.force_encoding("UTF-8")
               when Date, Icalendar::Values::DateTime
                 value.to_time
+              when Icalendar::Values::Uri
+                value.to_s
               else
                 value
               end

--- a/lib/jekyll-ical-tag.rb
+++ b/lib/jekyll-ical-tag.rb
@@ -116,14 +116,24 @@ module Jekyll
     end
 
     def get_url_from_page_attributes(context)
-      # Dereference url from something like "page.calender_url" to the page's calendar_url
-      dig_attrs = @url.split(".")
-      dig_attrs[0] = dig_attrs[0].to_sym if dig_attrs[0].present?
+      return if is_valid_url?(@url)
 
-      context.registers.dig(*dig_attrs) # will return result or nil (if not found)
+      # Dereference url from something like "page.calendar_url" to the page's calendar_url
+      attributes = @url.split(".")
+      attributes[0] = attributes[0].to_sym if attributes[0].present?
+
+      result = context.registers
+      attributes.each { |attribute| result = result&.fetch(attribute) }
+
+      if is_valid_url?(result)
+        result
+      else
+        nil
+      end
     end
 
     def get_url_from_assigned_value(context)
+      return if is_valid_url?(@url)
       return unless scope = context.scopes.find { |scope| scope[@url] }
 
       # Dereference the URL if we were passed a variable name.

--- a/lib/jekyll-ical-tag/event.rb
+++ b/lib/jekyll-ical-tag/event.rb
@@ -35,7 +35,7 @@ module Jekyll
         @simple_html_description ||= begin
             description&.clone.tap do |d|
               description_urls.each do |url|
-                d.gsub! url, %(<a href='#{url}'>#{url}</a>)
+                d.force_encoding("UTF-8").gsub! url, %(<a href='#{url}'>#{url}</a>)
               end
             end
           end

--- a/lib/jekyll-ical-tag/event.rb
+++ b/lib/jekyll-ical-tag/event.rb
@@ -46,7 +46,7 @@ module Jekyll
       end
 
       def description_urls
-        @description_urls ||= description.to_s.scan(URL_REGEX).to_a
+        @description_urls ||= description.to_s.force_encoding("UTF-8").scan(URL_REGEX).to_a
       end
 
       private

--- a/lib/jekyll-ical-tag/version.rb
+++ b/lib/jekyll-ical-tag/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   class IcalTag < Liquid::Block
-    VERSION = "1.0.9"
+    VERSION = "1.1.0"
   end
 end


### PR DESCRIPTION
After reviewing https://github.com/jekyll/jekyll-gist/blob/master/lib/jekyll-gist/gist_tag.rb#L20-L43

It's clear there is a `context.key?` and `context[]` method to dereference all types of variables

Close #17 
Close #19 