### PR TITLE
Clarify `URL_REGEX` using free-spacing mode, stop on double quote.

### DIFF
--- a/lib/jekyll-ical-tag/event.rb
+++ b/lib/jekyll-ical-tag/event.rb
@@ -6,7 +6,27 @@ require "uri"
 module Jekyll
   class IcalTag
     class Event
-      URL_REGEX = /(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!10(?:\.\d{1,3}){3})(?!127(?:\.\d{1,3}){3})(?!169\.254(?:\.\d{1,3}){2})(?!192\.168(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:\/[^\s]*)?/
+      URL_REGEX = /
+        (?:(?:https?|ftp):\/\/) # Allowable schemes
+        (?:\S+(?::\S*)?@)?      # username:password, which is optional
+        (?:                     # Domain part follows; non-capturing
+          # These IP addresses are valid domain values
+          (?!10(?:\.\d{1,3}){3})
+          (?!127(?:\.\d{1,3}){3})
+          (?!169\.254(?:\.\d{1,3}){2})
+          (?!192\.168(?:\.\d{1,3}){2})
+          (?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})
+          (?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])
+          (?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}
+          (?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))
+          |
+          (?:(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)
+          (?:\.(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)*
+          (?:\.(?:[a-z\u00a1-\uffff]{2,}))
+        )
+        (?::\d{2,5})?           # Optional port number
+        (?:\/[^\s"]*)?          # Anything that is not a space or a double quote
+        /x
       extend Forwardable
 
       def initialize(event)


### PR DESCRIPTION
This commit documents the gnarly `URL_REGEX` class constant. Ruby's
regex literal free-spacing mode (using the `x` modifier) is used to
accomplish this along with single-line comments.

The one and only change to the regular expression itself is in the final
part, where a double quote (`"`) character is added to the character
class that causes the regular expression to stop matching. This is done
because I have observed that many Google Calendar descriptions contain
HTML descriptions.

When an HTML link is defined in an iCalendar description property (as is
common for Google Calendar event authors, given GCal's rich text editing
mode), the description will contain a URL such as:

```
<a href="https://example.com/">Something.</a>
```

When a description like the above exists, AND no RFC 5545 `URL` property
exists in the input feed, then the `description_urls` method of this
file will incorrectly determine that the first URL is:

```
https://example.com/">Something.</a>
```

If this variable is then used in a Liquid template as, for example:

```
<a href="{{ event.url }}">{{ event.summary }}</a>
```

the resulting HTML will actually be the unexpected value:

```
<a href="https://example.com/">Something.</a>"&gt;Example Event Summary&lt;/a&gt;
```

A better solution to what is presented here would be more explicit URI
parsing, but given that the most popular iCalendar generators always use
a double quote character for enclosing HTML attributes, this should be
safe and is simple enough for now.