### PR TITLE
Fixes #26, fixes #27: Pass tag attributes to new coordinator.

### DIFF
--- a/lib/jekyll-ical-tag.rb
+++ b/lib/jekyll-ical-tag.rb
@@ -36,7 +36,11 @@ module Jekyll
       context.stack do
         url = get_dereferenced_url(context) || @url
 
-        calendar_feed_coordinator = CalendarFeedCoordinator.new(url: url)
+        calendar_feed_coordinator = CalendarFeedCoordinator.new(
+          url: url, only: @only, reverse: @reverse,
+          before_date: @before_date, after_date: @after_date,
+          limit: @limit
+        )
         events = calendar_feed_coordinator.events
         event_count = events.length
 


### PR DESCRIPTION
Probably not the most elegant solution, but in testing the latest
release I noticed that none of the `ical` tag attributes were being
recognized. I traced this down to the fact that there was no longer a
place where the tag's attributes, despite being recognized and set as
class attributes, were being passed to the newly introduced
`CalendarFeedCoordinator` object, which is now what calls the iCalendar
feed parser. That's where these values ultimately have to go.

This commit simply passes them along to the coordinator via its
constructor method.